### PR TITLE
Make tree self-update when children are added/removed

### DIFF
--- a/source/class/qxl/datagrid/binding/Bindings.js
+++ b/source/class/qxl/datagrid/binding/Bindings.js
@@ -1,23 +1,23 @@
 /* ************************************************************************
-*
-*    Qooxdoo DataGrid
-*
-*    https://github.com/qooxdoo/qooxdoo
-*
-*    Copyright:
-*      2022-23 Zenesis Limited, https://www.zenesis.com
-*
-*    License:
-*      MIT: https://opensource.org/licenses/MIT
-*
-*      This software is provided under the same licensing terms as Qooxdoo,
-*      please see the LICENSE file in the Qooxdoo project's top-level directory
-*      for details.
-*
-*    Authors:
-*      * John Spackman (john.spackman@zenesis.com, @johnspackman)
-*
-* *********************************************************************** */
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+ *
+ * *********************************************************************** */
 
 /**
  * Instead of just an opaque "binding id" as returned by `qx.core.Object.bind`, which can only be
@@ -29,18 +29,34 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
   extend: qx.core.Object,
   implement: [qx.core.IDisposable],
 
-  construct(model, bindingId) {
+  /**
+   *
+   * @param {qx.data.Object} model The model to add the binding to
+   * @param {String} bindingId Id of binding
+   * @param {String} bindingType The type of the binding. Either "binding" or "listener". Defaults to binding. Set to "binding " if this is a binding to a property, or "listener" if it's for a listener added with "addListener".
+   */
+  construct(model, bindingId, bindingType) {
     super();
+    if (bindingType === undefined) bindingType = "binding";
     this.__bindingData = [];
     if (model && bindingId) {
-      this.add(model, bindingId);
+      this.add(model, bindingId, bindingType);
     }
   },
 
   destruct() {
     this.__bindingData.forEach(data => {
       if (!data.model.isDisposed() && !data.model.isDisposing()) {
-        data.model.removeBinding(data.bindingId);
+        switch (data.bindingType) {
+          case "binding":
+            data.model.removeBinding(data.bindingId);
+            break;
+          case "listener":
+            data.model.removeListenerById(data.bindingId);
+            break;
+          default:
+            throw new Error("Invalid binding type" + data.bindingType);
+        }
       }
     });
   },
@@ -60,10 +76,17 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
      * @param {qx.core.Object} model the object with a binding
      * @param {*} bindingId the binding ID to release
      */
-    add(model, bindingId) {
+    add(model, bindingId, bindingType) {
       this.__bindingData.push({
         model,
-        bindingId
+        bindingId,
+        bindingType
+      });
+    },
+
+    release() {
+      this.__bindingData.forEach(data => {
+        data.model.removeBinding(data.bindingId);
       });
     }
   }

--- a/source/class/qxl/datagrid/demo/biggrid/BigGridDemo.js
+++ b/source/class/qxl/datagrid/demo/biggrid/BigGridDemo.js
@@ -96,12 +96,15 @@ qx.Class.define("qxl.datagrid.demo.biggrid.BigGridDemo", {
     _createQxObjectImpl(id) {
       switch (id) {
         case "dataSource":
+          // Create a massive data source with 1,000,000 rows and 10,000 columns
           return new qxl.datagrid.demo.biggrid.DummyDataSource(1000000, 10000);
 
         case "grid":
           var dataSource = this.getQxObject("dataSource");
           var columns = new qxl.datagrid.column.Columns();
           for (let columnIndex = 0; columnIndex < dataSource.getNumColumns(); columnIndex++) {
+            // One column definition does not take uyp much space, so although we create 10,000
+            //  columns that shouldnt be much of a problem
             let column = new qxl.datagrid.column.TextColumn().set({
               caption: qxl.datagrid.util.Labels.getColumnLetters(columnIndex),
               path: "label",
@@ -113,6 +116,8 @@ qx.Class.define("qxl.datagrid.demo.biggrid.BigGridDemo", {
           var grid = new qxl.datagrid.DataGrid(columns).set({
             dataSource: dataSource
           });
+
+          // Adjust the default selection style
           grid.getSelectionManager().set({
             selectionStyle: "cell",
             selectionMode: "multi"

--- a/source/class/qxl/datagrid/source/tree/INodeInspector.js
+++ b/source/class/qxl/datagrid/source/tree/INodeInspector.js
@@ -38,6 +38,15 @@ qx.Interface.define("qxl.datagrid.source.tree.INodeInspector", {
      * @param {qx.core.Object?} node
      * @return {Boolean}
      */
-    canHaveChildren(node) {}
+    canHaveChildren(node) {},
+
+    /**
+     *
+     * @param {qx.core.Object} node
+     * @param {Function} fn
+     * @param {Object?} context
+     * @return {qxl.datagrid.binding.Bindings}
+     */
+    addChildrenChangeListener(node, fn, context) {}
   }
 });

--- a/source/class/qxl/datagrid/source/tree/ITreeDataSource.js
+++ b/source/class/qxl/datagrid/source/tree/ITreeDataSource.js
@@ -1,23 +1,23 @@
 /* ************************************************************************
-*
-*    Qooxdoo DataGrid
-*
-*    https://github.com/qooxdoo/qooxdoo
-*
-*    Copyright:
-*      2022-23 Zenesis Limited, https://www.zenesis.com
-*
-*    License:
-*      MIT: https://opensource.org/licenses/MIT
-*
-*      This software is provided under the same licensing terms as Qooxdoo,
-*      please see the LICENSE file in the Qooxdoo project's top-level directory
-*      for details.
-*
-*    Authors:
-*      * John Spackman (john.spackman@zenesis.com, @johnspackman)
-*
-* *********************************************************************** */
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+ *
+ * *********************************************************************** */
 
 /**
  * Defines the additional methods for a datasource for trees (eg specifies what the `qxl.datagrid.*.tree.*`
@@ -36,6 +36,20 @@ qx.Interface.define("qxl.datagrid.source.tree.ITreeDataSource", {
      * @param {qx.core.Object} model
      * @return {NodeState}
      */
-    getNodeStateFor(model) {}
+    getNodeStateFor(model) {},
+
+    /**
+     * Expands a node
+     *
+     * @param {qx.core.Object} node
+     */
+    async expandNode(node) {},
+
+    /**
+     * Collapses a node
+     *
+     * @param {qx.core.Object} node
+     */
+    async collapseNode(node) {}
   }
 });

--- a/source/class/qxl/datagrid/source/tree/NodeInspector.js
+++ b/source/class/qxl/datagrid/source/tree/NodeInspector.js
@@ -52,6 +52,23 @@ qx.Class.define("qxl.datagrid.source.tree.NodeInspector", {
      */
     canHaveChildren(node) {
       return true;
+    },
+
+    /**
+     * @override
+     *
+     * N.b. This is deprecated. Use addChildrenChangeBinding instead
+     */
+    addChildrenChangeListener(node, fn, context) {
+      return node.get(this.getChildrenPath()).addListener("change", fn, context);
+    },
+
+    removeChildrenChangeListener(node, id) {
+      return node.get(this.getChildrenPath()).removeListenerById(id);
+    },
+
+    createChildrenChangeBinding(node, fn, context) {
+      return new qxl.datagrid.binding.Bindings(node.get(this.getChildrenPath()), node.get(this.getChildrenPath()).addListener("change", fn, context), "listener");
     }
   }
 });

--- a/source/class/qxl/datagrid/source/tree/TreeDataSource.js
+++ b/source/class/qxl/datagrid/source/tree/TreeDataSource.js
@@ -29,8 +29,8 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
 
   construct(nodeInspectorFactory, columns) {
     super();
-    this.__rows = [];
-    this.__rowsByNode = {};
+    this.__rowMetaDatas = [];
+    this.__rowMetaDataByNode = {};
     this.__queue = [];
     if (nodeInspectorFactory) {
       this.setNodeInspectorFactory(nodeInspectorFactory);
@@ -60,15 +60,17 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
 
   members: {
     /**
-     * @typedef RowData
+     * @typedef RowMetaData
      * @property {qx.core.Object} node the node object for the row
      * @property {Integer} level indentation level
+     * @property {Boolean} canHaveChildren whether the node might have children
+     * @property {qxl.datagrid.binding.Bindings} childrenChangeListener Binding object for the change listener of the node's children
      *
-     * @type{RowData[]} array of objects for each row */
-    __rows: null,
+     * @type{RowMetaData[]} array of objects for each row */
+    __rowMetaDatas: null,
 
-    /** @type{Map<String,Object>} map of rows indexed by hash code of the node */
-    __rowsByNode: null,
+    /** @type{Map<String,RowMetaData>} map of rows indexed by hash code of the node */
+    __rowMetaDataByNode: null,
 
     /* @type{Promise[]?} queue of promises of background actions, eg loading nodes */
     __queue: null,
@@ -78,17 +80,35 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      */
     async __applyRoot(value) {
       this._data = {};
-      this.__rows = [];
+      this.__rowMetaDatas = [];
       if (value) {
         let inspector = this.getNodeInspectorFactory()(value);
+
         await this.queue(async () => {
-          for (let i = 0, nodes = await inspector.getChildrenOf(value); i < nodes.length; i++) {
-            let node = nodes.getItem(i);
-            let row = this.__createRow(node, 0);
-            row.canHaveChildren = inspector.canHaveChildren(node);
-            this.__rows.push(row);
-            this.__rowsByNode[node.toHashCode()] = row;
-          }
+          let row = this.__createRowMetaData(value, -1);
+          let addChildRows = async () => {
+            row.childRows = [];
+            this.__rowMetaDataByNode[value.toHashCode()] = row;
+
+            for (let i = 0, nodes = await inspector.getChildrenOf(value); i < nodes.length; i++) {
+              let node = nodes.getItem(i);
+              let childRow = this.__createRowMetaData(node, 0);
+              let childInspector = this.getNodeInspectorFactory()(node);
+
+              childRow.canHaveChildren = childInspector.canHaveChildren(node);
+              this.__rowMetaDatas.push(childRow);
+              this.__rowMetaDataByNode[node.toHashCode()] = childRow;
+              row.childRows.push(childRow);
+            }
+            this.fireDataEvent("changeSize", this.getSize());
+          };
+          let onRootChildrenChange = async () => {
+            this._removeChildRows(row);
+            await addChildRows();
+          };
+          row.canHaveChildren = inspector.canHaveChildren(value);
+          if (!row.childrenChangeBinding) row.childrenChangeBinding = inspector.createChildrenChangeBinding(value, onRootChildrenChange);
+          await addChildRows();
         });
       }
       this.fireDataEvent("changeSize", this.getSize());
@@ -99,67 +119,113 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      *
      * @param {qx.core.Object} node
      * @param {Integer} level the indentation level
-     * @returns {RowData}
+     * @returns {RowMetaData}
      */
-    __createRow(node, level) {
+    __createRowMetaData(node, level) {
       return {
         node: node,
-        level: level
+        level: level,
+        canHaveChildren: undefined,
+        childrenChangeBinding: undefined
       };
     },
 
     /**
-     * Expands a node
-     *
-     * @param {qx.core.Object} node
+     * @override
      */
     async expandNode(node) {
-      let row = this.__rowsByNode[node.toHashCode()];
-      if (!row) {
+      let rowMetadata = this.__rowMetaDataByNode[node.toHashCode()];
+      if (!rowMetadata) {
         throw new Error(`Cannot find ${node} in rows`);
       }
-      if (row.childRows) {
+      if (rowMetadata.childRows || !rowMetadata.canHaveChildren) {
         return;
       }
 
       let inspector = this.getNodeInspectorFactory()(node);
       await this.queue(async () => {
         let children = await inspector.getChildrenOf(node);
-        row = this.__rowsByNode[node.toHashCode()]; // In case the index has changed
-        if (!row) {
+        rowMetadata = this.__rowMetaDataByNode[node.toHashCode()]; // In case the index has changed
+        if (!rowMetadata) {
           return;
         }
-        let parentRowIndex = this.__rows.indexOf(row);
+        rowMetadata.childrenChangeBinding = inspector.createChildrenChangeBinding(node, evt => this._onNodeChildrenChange(evt, node));
+        let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
         let childRows = [];
         for (let childNode of children) {
-          let childRow = this.__createRow(childNode, row.level + 1);
+          let childRow = this.__createRowMetaData(childNode, rowMetadata.level + 1);
           childRow.canHaveChildren = inspector.canHaveChildren(childNode);
           childRows.push(childRow);
-          this.__rowsByNode[childNode.toHashCode()] = childRow;
+          this.__rowMetaDataByNode[childNode.toHashCode()] = childRow;
         }
-        let before = this.__rows.slice(0, parentRowIndex + 1);
-        let after = parentRowIndex == this.__rows.length - 1 ? [] : this.__rows.slice(parentRowIndex + 1);
+        let before = this.__rowMetaDatas.slice(0, parentRowIndex + 1);
+        let after = parentRowIndex == this.__rowMetaDatas.length - 1 ? [] : this.__rowMetaDatas.slice(parentRowIndex + 1);
         qx.lang.Array.append(before, childRows);
         qx.lang.Array.append(before, after);
-        row.childRows = childRows;
-        this.__rows = before;
+        rowMetadata.childRows = childRows;
+        this.__rowMetaDatas = before;
         this.fireDataEvent("changeSize", this.getSize());
       });
     },
 
     /**
-     * Collapses a node
-     *
-     * @param {qx.core.Object} node
+     * Evcent handler for changes to a row's children
+     */
+    async _onNodeChildrenChange(evt, node) {
+      // removeStart = parenVtindex + 1 + evt.start
+      // removeend = parentindex + 1 + evt.end
+      // metadatas.remove between start and end
+      // metadatas.insert new children at start
+      rowMetadata = this.__rowMetaDataByNode[node.toHashCode()]; // In case the index has changed
+      let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
+      let changeStart = parentRowIndex + 1;
+      let changeEnd = changeStart + rowMetadata.childRows.length;
+      let before = this.__rowMetaDatas.slice(0, changeStart);
+      let after = changeEnd == this.__rowMetaDatas.length ? [] : this.__rowMetaDatas.slice(changeEnd);
+      await this.queue(async () => {
+        for (let childRow of rowMetadata.childRows) {
+          this._removeChildRows(childRow);
+        }
+        rowMetadata.childRows = [];
+        let newRowsMetaDatas = [];
+        for (let childNode of node.getChildren()) {
+          let inspector = this.getNodeInspectorFactory()(childNode);
+          let childRowMetadata = this.__createRowMetaData(childNode, rowMetadata.level + 1);
+          newRowsMetaDatas.push(childRowMetadata);
+          childRowMetadata.canHaveChildren = inspector.canHaveChildren(childNode);
+          rowMetadata.childRows.push(childRowMetadata);
+          this.__rowMetaDataByNode[childNode.toHashCode()] = childRowMetadata;
+        }
+        qx.lang.Array.append(before, newRowsMetaDatas);
+        qx.lang.Array.append(before, after);
+        this.__rowMetaDatas = before;
+        this.fireDataEvent("changeSize", this.getSize());
+      });
+    },
+    /**
+     * @override
      */
     async collapseNode(node) {
-      let row = this.__rowsByNode[node.toHashCode()];
+      //!todo release binding
+      let row = this.__rowMetaDataByNode[node.toHashCode()];
       if (!row) {
         throw new Error(`Cannot find ${node} in rows`);
       }
       if (!row.childRows) {
         return;
       }
+      if (row.childrenChangeBinding) {
+        row.childrenChangeBinding.dispose();
+        delete row.childrenChangeBinding;
+      }
+      this._removeChildRows(row);
+      this.fireDataEvent("changeSize", this.getSize());
+    },
+    /**
+     * Recursively removes metatdats of children of specified row, from this.__rowMetaDatas
+     * @param {JavaScript Object} row Metadata for row for which to remove children
+     */
+    _removeChildRows(row) {
       let toRemove = [];
       const removeChildRows = row => {
         if (row.childRows) {
@@ -172,10 +238,9 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
       removeChildRows(row);
       delete row.childRows;
       for (let childRow of toRemove) {
-        delete this.__rowsByNode[childRow.node.toHashCode()];
-        qx.lang.Array.remove(this.__rows, childRow);
+        delete this.__rowMetaDataByNode[childRow.node.toHashCode()];
+        qx.lang.Array.remove(this.__rowMetaDatas, childRow);
       }
-      this.fireDataEvent("changeSize", this.getSize());
     },
 
     /**
@@ -235,9 +300,9 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      * @override
      */
     getPositionOfModel(node) {
-      let row = this.__rowsByNode[node.toHashCode()] || null;
+      let row = this.__rowMetaDataByNode[node.toHashCode()] || null;
       if (row !== null) {
-        let rowIndex = this.__rows.indexOf(row);
+        let rowIndex = this.__rowMetaDatas.indexOf(row);
         return new qxl.datagrid.source.Position(rowIndex, 0);
       }
       return null;
@@ -247,7 +312,7 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      * @override
      */
     getNodeStateFor(node) {
-      let row = this.__rowsByNode[node.toHashCode()] || null;
+      let row = this.__rowMetaDataByNode[node.toHashCode()] || null;
       if (!row) {
         return null;
       }
@@ -264,10 +329,10 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      * @returns {*}
      */
     getNode(rowIndex) {
-      if (rowIndex >= this.__rows.length) {
+      if (rowIndex >= this.__rowMetaDatas.length) {
         return null;
       }
-      let row = this.__rows[rowIndex];
+      let row = this.__rowMetaDatas[rowIndex];
       return row.node;
     },
 
@@ -275,7 +340,7 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      * @Override
      */
     getSize() {
-      return new qxl.datagrid.source.Position(this.__rows?.length || 0, 1);
+      return new qxl.datagrid.source.Position(this.__rowMetaDatas?.length || 0, 1);
     }
   }
 });


### PR DESCRIPTION
This commit makes the children of expanded nodes in a data grid automatically update when the children of their corresponding nodes in the datasource are added/removed.