### PR TITLE
column: binding options factory

### DIFF
--- a/source/class/qxl/datagrid/column/Column.js
+++ b/source/class/qxl/datagrid/column/Column.js
@@ -89,6 +89,10 @@ qx.Class.define("qxl.datagrid.column.Column", {
       check: "Boolean",
       apply: "_applyReadOnly",
       event: "changeReadOnly"
+    },
+
+    bindingOptionsFactory: {
+      init: () => undefined
     }
   },
 
@@ -160,7 +164,7 @@ qx.Class.define("qxl.datagrid.column.Column", {
      * @returns {*?}
      */
     _getBindingOptions(widget, model) {
-      return undefined;
+      return this.getBindingOptionsFactory()(widget, model);
     },
 
     /**

--- a/source/class/qxl/datagrid/column/Column.js
+++ b/source/class/qxl/datagrid/column/Column.js
@@ -91,7 +91,7 @@ qx.Class.define("qxl.datagrid.column.Column", {
       event: "changeReadOnly"
     },
 
-    bindingOptionsFactory: {
+    bindingOptions: {
       init: () => undefined
     }
   },
@@ -140,7 +140,7 @@ qx.Class.define("qxl.datagrid.column.Column", {
       let path = this.getPath();
       if (path) {
         if (model) {
-          let bindingId = model.bind(path, widget, "value", this._getBindingOptions(widget, model));
+          let bindingId = model.bind(path, widget, "value", this.getBindingOptions()(widget, model));
           return new qxl.datagrid.binding.Bindings(model, bindingId);
         }
       } else {
@@ -154,17 +154,6 @@ qx.Class.define("qxl.datagrid.column.Column", {
      */
     createWidgetForDisplay() {
       return new qx.ui.basic.Label();
-    },
-
-    /**
-     * Returns options for the binding
-     *
-     * @param {qx.ui.core.Widget} widget
-     * @param {qx.core.Object} model
-     * @returns {*?}
-     */
-    _getBindingOptions(widget, model) {
-      return this.getBindingOptionsFactory()(widget, model);
     },
 
     /**


### PR DESCRIPTION
Allows one to provide widget binding options for a column without having to subclass the column class and override _getBindingOptions