### PR TITLE
Eliminate getDisplayValue and _getBindingOptions

### DIFF
--- a/source/class/qxl/datagrid/column/Column.js
+++ b/source/class/qxl/datagrid/column/Column.js
@@ -103,32 +103,6 @@ qx.Class.define("qxl.datagrid.column.Column", {
 
   members: {
     /**
-     * Returns a value for displaying the value for the column
-     *
-     * @param {*} node
-     * @return {String}
-     */
-    getDisplayValue(node) {
-      let path = this.getPath();
-      if (!path) {
-        return node;
-      }
-      let upname = qx.lang.String.firstUp(path);
-      let value = node["get" + upname]();
-      value = this._convertValueForDisplay(value);
-      return value;
-    },
-
-    /**
-     * Helper method that converts the model into a text value for display, used by bindings and `getDisplayValue`
-     * @param {*} value returned by the binding, according to the path
-     * @returns {String}
-     */
-    _convertValueForDisplay(value) {
-      return value;
-    },
-
-    /**
      * Called to implement the binding
      *
      * @param {qx.ui.core.Widget} widget

--- a/source/class/qxl/datagrid/column/DateColumn.js
+++ b/source/class/qxl/datagrid/column/DateColumn.js
@@ -32,26 +32,15 @@ qx.Class.define("qxl.datagrid.column.DateColumn", {
       event: "changeDateFormat"
     }
   },
-
-  members: {
-    /**
-     * @override
-     */
-    _convertValueForDisplay(value) {
-      let format = this.getDateFormat() || qx.util.format.DateFormat.getDateInstance();
-      return !value ? "" : format.format(value);
-    },
-
-    /**
-     * @override
-     */
-    _getBindingOptions(widget, model) {
+  construct() {
+    super();
+    this.setBindingOptions((widget, model) => {
       return {
         converter: (data, model, source, target) => {
           let format = this.getDateFormat() || qx.util.format.DateFormat.getDateInstance();
           return !data ? "" : format.format(data);
         }
       };
-    }
+    });
   }
 });

--- a/source/class/qxl/datagrid/column/FileSizeColumn.js
+++ b/source/class/qxl/datagrid/column/FileSizeColumn.js
@@ -32,11 +32,18 @@ qx.Class.define("qxl.datagrid.column.FileSizeColumn", {
       check: "Binary"
     }
   },
+  construct() {
+    super();
+    this.setBindingOptions((widget, model) => {
+      return {
+        converter: (data, model, source, target) => {
+          return !data ? "" : this._convertValueForDisplay(data);
+        }
+      };
+    });
+  },
 
   members: {
-    /**
-     * @override
-     */
     _convertValueForDisplay(value) {
       if (typeof value != "number") {
         return "";
@@ -53,17 +60,6 @@ qx.Class.define("qxl.datagrid.column.FileSizeColumn", {
         return "" + Math.round(value / (multiplier * multiplier)) + "MB";
       }
       return "" + Math.round(value / (multiplier * multiplier * multiplier)) + "GB";
-    },
-
-    /**
-     * @override
-     */
-    _getBindingOptions(widget, model) {
-      return {
-        converter: (data, model, source, target) => {
-          return !data ? "" : this._convertValueForDisplay(data);
-        }
-      };
     }
   }
 });


### PR DESCRIPTION
We can now set the `bindingOptions` property instead of overriding `_getBindingOptions` when subclassing `Column`. This eliminates the need to subclass Column in order to set the binding options. `_getDisplayValue` was also removed because it is not called anywhere. 