### PR TITLE
Array DataGrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .package-cache.json
 /node_modules/
 /tmp/
+/notes
 launch.json

--- a/compile.json
+++ b/compile.json
@@ -24,7 +24,7 @@
   "applications": [
     {
       "class": "qxl.datagrid.demo.Application",
-      "theme": "qxl.datagrid.demo.theme.Theme",
+      "theme": "qxl.datagrid.demo.theme.tangible.Theme",
       "name": "qxl.datagrid",
       "bootPath": "source/boot"
     }

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,38 @@ to say how big the data is and get values from your array.
 One crucial point to note is that although `makeAvailable` is called with a range of columns & rows, your DataSource
 MUST always also provide a model for column 0 (zero) for each row in that range - this is to allow selection by row.
 
+### Array Data Sources
+
+Array data sources use a simple one-dimensional array of model objects, with each model in the array representing one
+row of data. This same model is then passed to each column of the corresponding row in the DataGrid, satisfying the
+requirement for two-dimensional data. Each column will display some property of that object as configured, allowing for
+a simplified list-like or table-like presentation.
+
+For most use cases, it will be sufficient to instantiate [qxl.datagrid.source.ArrayDataSource](source/class/qxl/datagrid/source/ArrayDataSource.js) and
+set it's `model` property to your array of model objects. However some cases with larger datasets may prefer to make
+trips to the server; typically this can be handled by extending [qxl.datagrid.source.ArrayDataSource](source/class/qxl/datagrid/source/ArrayDataSource.js) and overriding
+the `IsAvailable`, `makeAvailable`, and `getSize` members.
+
+For the former use case, the implementation is quite simple. Below is a snippet containing a very basic example of how
+to use an ArrayDataSource with a DataGrid - bear in mind this snippet is intended to be illustrative, not effective.
+
+```js
+const myColumns = new qxl.datagrid.column.Columns();            // create a new columns object
+myColumns.add(/* ... */);                                       // add columns to the columns object as required
+
+const myGrid = new qxl.datagrid.DataGrid(myColumns);            // create a new datagrid
+
+const myDataSource = new qxl.datagrid.source.ArrayDataSource(); // create a new array data source
+myGrid.set({ dataSource: myDataSource });                       // set the data source on the grid
+
+const myDataArray = myapp.model.MyModel.getAll();               // generate/fetch some `qx.data.Array` of model objects
+myDataSource.setModel(myDataArray);                             // set the model on the data source
+
+                                                                // Done!
+```
+
+For a more purpose-built example, take a look at [qxl.datagrid.demo.array.ArrayDemo](source/class/qxl/datagrid/demo/array/ArrayDemo.js)
+
 ### Tree Data Sources
 
 For a spreadsheet-style datagrid, your data is already in a two-dimensional array, but tree-style datagrid has a heirarchy

--- a/readme.md
+++ b/readme.md
@@ -58,13 +58,13 @@ qx.Theme.define("myapp.theme.Appearance", {
 });
 ```
 
-Do the same for your `Decoration` and `Color`.
-
 Currently, the following themes are supported:
 
-- Tangible (light & dark)
-- Indigo & Indigo Dark
-- Simple
+- Tangible (light & dark) - use `qxl.datagrid.theme.tangible.*` mixins
+- Indigo & Indigo Dark - use `qxl.datagrid.theme.indigo.*` mixins
+- Simple - use `qxl.datagrid.theme.simple.*` mixins
+
+For each theme, there are three available mixins; `*.MAppearance`, `*.MColor`, and `*.MDecoration`.
 
 ## Key Concepts
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@ NOTE:: This is beta release, but will be in active use and development over he n
 ### Coming Soon (tm)
 
 - The current version is read only, but it will be possible to add edit cells inline in the near future.
-- The theme additions are only really compatible with Tangible - it would be easy to add mixins for other themes, but it's not been done yet
 
 ## Trying the Demos
 
@@ -55,14 +54,17 @@ into your own application's theme. For example, if you app is called `myapp`, yo
 qx.Theme.define("myapp.theme.Appearance", {
   extend: qx.theme.tangible.Appearance,
 
-  include: [qxl.datagrid.theme.MAppearance]
+  include: [qxl.datagrid.theme.tangible.MAppearance]
 });
 ```
 
 Do the same for your `Decoration` and `Color`.
 
-NOTE:: the theming for DataGrid is only really compatible with the Tangible theme at the moment, so if you use another theme you
-may have some more work to do. Please consider contributing your appearances for other themes back to this project!
+Currently, the following themes are supported:
+
+- Tangible (light & dark)
+- Indigo & Indigo Dark
+- Simple
 
 ## Key Concepts
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ NOTE:: This is beta release, but will be in active use and development over he n
 
 Included in this repo is a demo application - it's running live at http://qooxdoo.org/qxl-datagrid.qooxdoo.github.io/
 
-The included demo application will create a tabview showing both styles of DataGrid usage (ie spreadsheet or tree); if you would like
+The included demo application will create a tabview showing several styles of DataGrid usage; if you would like
 to try it out on your own computer, check out this repo and run it:
 
 ```
@@ -28,6 +28,12 @@ $ qx serve
 ```
 
 and browse to http://localhost:8080
+
+Currently the following demos are included:
+
+- Array - displays a simple array of model objects using [qxl.datagrid.source.ArrayDataSource](source/class/qxl/datagrid/source/ArrayDataSource.js)
+- Tree - displays the file system at `./source` using [qxl.datagrid.source.tree.TreeDataSource](source/class/qxl/datagrid/source/tree/TreeDataSource.js)
+- Big Grid - displays a large (10 billion entry) grid of data using a custom [qxl.datagrid.source.IDataSource](source/class/qxl/datagrid/source/IDataSource.js) implementation
 
 ## Getting Started
 

--- a/source/class/qxl/datagrid/DataGrid.js
+++ b/source/class/qxl/datagrid/DataGrid.js
@@ -25,7 +25,7 @@
 qx.Class.define("qxl.datagrid.DataGrid", {
   extend: qx.ui.core.Widget,
   implement: [qxl.datagrid.ui.IWidgetSizeSource],
-  include: [qx.ui.core.scroll.MScrollBarFactory, qx.ui.core.scroll.MRoll],
+  include: [qx.ui.core.scroll.MScrollBarFactory],
 
   /**
    * Constructor
@@ -105,7 +105,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
     startRowIndex: {
       init: 0,
       check: "Integer",
-      apply: "updateWidgets",
+      apply: "_applyStartRowIndex",
       event: "changeStartRowIndex"
     },
 
@@ -170,6 +170,8 @@ qx.Class.define("qxl.datagrid.DataGrid", {
   },
 
   members: {
+    /** @type{Boolean} True if _applyStartRowIndex is being called */
+    __inApplyStartRowIndex: false,
     /** @type{qxl.datagrid.ui.GridSizeCalculator} */
     __sizeCalculator: null,
 
@@ -182,6 +184,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
     /** @type{qxl.datagrid.selection.SelectionManager} the selection manager */
     __selectionManager: null,
 
+    _cancelRoll: null,
     /**
      * Apply for `columns`
      */
@@ -214,6 +217,12 @@ qx.Class.define("qxl.datagrid.DataGrid", {
       }
     },
 
+    _applyStartRowIndex() {
+      this.__inApplyStartRowIndex = true;
+      this.updateWidgets();
+      this.__inApplyStartRowIndex = false;
+    },
+
     /**
      * Event handler for changes in the data source's size
      */
@@ -221,6 +230,70 @@ qx.Class.define("qxl.datagrid.DataGrid", {
       this.getQxObject("widgetPane").invalidateAll();
       this.__sizeCalculator.invalidate();
       this.updateWidgets();
+    },
+
+    /**
+     * Responsible for adding the event listener needed for scroll handling.
+     */
+    _addRollHandling() {
+      this.addListener("roll", this._onRoll, this);
+      this.addListener("pointerdown", this._onPointerDownForRoll, this);
+    },
+
+    /**
+     * Responsible for removing the event listener needed for scroll handling.
+     */
+    _removeRollHandling() {
+      this.removeListener("roll", this._onRoll, this);
+      this.removeListener("pointerdown", this._onPointerDownForRoll, this);
+    },
+
+    /**
+     * Handler for the pointerdown event which simply stops the momentum scrolling.
+     *
+     * @param e {qx.event.type.Pointer} pointerdown event
+     */
+    _onPointerDownForRoll(e) {
+      this._cancelRoll = e.getPointerId();
+    },
+
+    _onRoll(e) {
+      const SCROLLING_SPEED = 0.08;
+      // only wheel and touch
+      if (e.getPointerType() == "mouse") {
+        return;
+      }
+
+      if (this._cancelRoll && e.getMomentum()) {
+        e.stopMomentum();
+        this._cancelRoll = null;
+        return;
+      }
+
+      let rowCount = this.getDataSourceSize().getRow();
+      var newStartRowIndex = this.getStartRowIndex() + Math.floor(e.getDelta().y * SCROLLING_SPEED);
+      let maxRows = this.getMaxRows();
+      newStartRowIndex = qxl.datagrid.util.Math.clamp(0, Math.max(0, rowCount - maxRows), newStartRowIndex);
+      this.setStartRowIndex(newStartRowIndex);
+    },
+
+    /**
+     * @returns The number of maximum rows that the data grid can display in view.
+     */
+    getMaxRows() {
+      const styling = this.__sizeCalculator.getStyling();
+      return Math.floor(this.getQxObject("oddEvenRows").getBounds().height / (styling.getMinRowHeight() || styling.getMaxRowHeight())) - 1;
+    },
+
+    /**
+     * Scrolls the tree such that the selected item is in the center.
+     * If it's not possible to center the item, it is shown as close to the center as possible.
+     */
+    scrollToSelection() {
+      let selectedModel = this.getSelection().getItem(0);
+      let selectionIndex = this.getDataSource().getPositionOfModel(selectedModel).getRow();
+      let maxRowCount = this.getMaxRows();
+      this.setStartRowIndex(Math.max(0, selectionIndex - Math.floor(maxRowCount / 2)));
     },
 
     /**
@@ -242,6 +315,10 @@ qx.Class.define("qxl.datagrid.DataGrid", {
         height: null,
         maxHeight: maxHeight
       };
+    },
+
+    _getSizeCalculator() {
+      return this.__sizeCalculator;
     },
 
     /**
@@ -329,14 +406,9 @@ qx.Class.define("qxl.datagrid.DataGrid", {
         scrollbarY.setVisibility("excluded");
       } else {
         scrollbarY.setVisibility("visible");
-        let percent;
-        if (this.getStartRowIndex() == 0) {
-          percent = 0;
-        } else if (this.getStartRowIndex() == -1 || sizeData.rows.length == size.getRow() - this.getStartRowIndex()) {
-          percent = 100;
-        } else {
-          percent = Math.floor((this.getStartRowIndex() / size.getRow()) * 100);
-        }
+        if (this.getMaxRows() >= size.getRow()) percent = 0;
+        else percent = Math.floor(qxl.datagrid.util.Math.interpolate(0, Math.max(0, size.getRow() - this.getMaxRows()), 0, 100, this.getStartRowIndex()));
+        percent = Math.min(percent, 100);
         scrollbarY.set({
           position: percent
         });
@@ -376,14 +448,12 @@ qx.Class.define("qxl.datagrid.DataGrid", {
 
           control.exclude();
           control.addListener("scroll", e => {
+            if (this.__inApplyStartRowIndex) return;
             let position = e.getData();
-            let size = this.getDataSource().getSize();
-            if (position == 100) {
-              this.setStartRowIndex(-1);
-            } else {
-              let start = Math.round(size.getRow() * (position / 100));
-              this.setStartRowIndex(start);
-            }
+            let rowCount = this.getDataSource().getSize().getRow();
+            const startRowIndex = Math.floor(qxl.datagrid.util.Math.interpolate(0, 100, 0, Math.max(0, rowCount - this.getMaxRows()), position));
+            this.setStartRowIndex(startRowIndex);
+            console.log("position: " + position + " start row index: " + startRowIndex);
           });
           control.addListener("changeVisibility", () => this.__onScrollbarVisibility("y"));
           return control;

--- a/source/class/qxl/datagrid/DataGrid.js
+++ b/source/class/qxl/datagrid/DataGrid.js
@@ -37,6 +37,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
     super();
     this.__debounceUpdateWidgets = new qxl.datagrid.util.Debounce(() => this.updateWidgets(), 50);
     this.__selectionManager = new qxl.datagrid.ui.SelectionManager();
+    this.__selectionManager.addListener("changeSelection", () => this.scheduleUpdateWidgets());
 
     columns = columns || null;
     styling = styling || new qxl.datagrid.ui.GridStyling();

--- a/source/class/qxl/datagrid/DataGrid.js
+++ b/source/class/qxl/datagrid/DataGrid.js
@@ -484,7 +484,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
           return comp;
 
         case "headerWidgetFactory":
-          return new qxl.datagrid.ui.factory.HeaderWidgetFactory(this.getColumns(), "qxl-datagrid-header-cell");
+          return new qxl.datagrid.ui.factory.HeaderWidgetFactory(this.getColumns())
 
         case "header":
           return new qxl.datagrid.ui.HeaderRows(this.__sizeCalculator, this.getQxObject("headerWidgetFactory"), this.getDataSource());
@@ -493,7 +493,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
           return new qxl.datagrid.ui.OddEvenRowBackgrounds(this.__sizeCalculator, this.getDataSource(), this.__selectionManager);
 
         case "paneWidgetFactory":
-          return new qxl.datagrid.ui.factory.SimpleWidgetFactory(this.getColumns(), "qxl-datagrid-cell");
+          return new qxl.datagrid.ui.factory.SimpleWidgetFactory(this.getColumns());
 
         case "widgetPane":
           return new qxl.datagrid.ui.WidgetPane(this.__sizeCalculator, this.getQxObject("paneWidgetFactory"), this.getDataSource(), this.__selectionManager);

--- a/source/class/qxl/datagrid/DataGrid.js
+++ b/source/class/qxl/datagrid/DataGrid.js
@@ -329,7 +329,7 @@ qx.Class.define("qxl.datagrid.DataGrid", {
     },
 
     /**
-     * Handles changes to the visibility of eiher scrollbar
+     * Handles changes to the visibility of either scrollbar
      *
      * @param {String} side either "x" or "y"
      */
@@ -535,7 +535,16 @@ qx.Class.define("qxl.datagrid.DataGrid", {
      * @Override
      */
     renderLayout(left, top, width, height) {
-      let changed = this.__sizeCalculator.setAvailableSize(width, height, this.getStartRowIndex(), this.getStartColumnIndex());
+      const initialOffsetLeft = this.getQxObject("widgetPane").getPaddingLeft();
+      const initialOffsetTop = this.getQxObject("widgetPane").getPaddingTop();
+      let changed = this.__sizeCalculator.setAvailableSize(
+        width - this.getChildControl("scrollbar-y").getSizeHint().width - initialOffsetLeft - this.getQxObject("widgetPane").getPaddingRight(),
+        height,
+        this.getStartRowIndex(),
+        this.getStartColumnIndex(),
+        initialOffsetLeft,
+        initialOffsetTop
+      );
       super.renderLayout(left, top, width, height);
       if (changed) {
         this.updateWidgets();

--- a/source/class/qxl/datagrid/binding/Bindings.js
+++ b/source/class/qxl/datagrid/binding/Bindings.js
@@ -37,7 +37,9 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
    */
   construct(model, bindingId, bindingType) {
     super();
-    if (bindingType === undefined) bindingType = "binding";
+    if (bindingType === undefined) {
+      bindingType = "binding";
+    }
     this.__bindingData = [];
     if (model && bindingId) {
       this.add(model, bindingId, bindingType);
@@ -46,6 +48,10 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
 
   destruct() {
     this.removeAll();
+  },
+
+  events: {
+    removeAll: "qx.event.type.Event"
   },
 
   members: {
@@ -104,6 +110,10 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
             data.model.removeListenerById(data.bindingId);
             break;
 
+          case "callback":
+            data.bindingId(data.model);
+            break;
+
           default:
             throw new Error("Invalid binding type" + data.bindingType);
         }
@@ -117,6 +127,7 @@ qx.Class.define("qxl.datagrid.binding.Bindings", {
       let arr = this.__bindingData;
       this.__bindingData = [];
       arr.forEach(data => this.__releaseData(data));
+      this.fireEvent("removeAll");
     }
   }
 });

--- a/source/class/qxl/datagrid/column/Column.js
+++ b/source/class/qxl/datagrid/column/Column.js
@@ -120,6 +120,7 @@ qx.Class.define("qxl.datagrid.column.Column", {
       } else {
         widget.setLabel(model);
       }
+      return new qxl.datagrid.binding.Bindings(model);
     },
 
     /**
@@ -127,7 +128,9 @@ qx.Class.define("qxl.datagrid.column.Column", {
      * @returns {qx.ui.core.Widget}
      */
     createWidgetForDisplay() {
-      return new qx.ui.basic.Label();
+      return new qx.ui.basic.Label().set({
+        appearance: "qxl-datagrid-cell"
+      });
     },
 
     /**

--- a/source/class/qxl/datagrid/column/tree/ExpansionLayout.js
+++ b/source/class/qxl/datagrid/column/tree/ExpansionLayout.js
@@ -30,6 +30,11 @@ qx.Class.define("qxl.datagrid.column.tree.ExpansionLayout", {
     spacing: {
       init: 3,
       check: "Integer"
+    },
+
+    position: {
+      init: "start",
+      check: ["start", "end"]
     }
   },
 
@@ -39,8 +44,8 @@ qx.Class.define("qxl.datagrid.column.tree.ExpansionLayout", {
      */
     renderLayout(availWidth, availHeight, padding) {
       let widget = this._getWidget();
-      let expander = widget.getChildControl("expander");
-      let label = widget.getChildControl("label");
+      let expander = widget.getExpander();
+      let label = widget.getLabel();
       label.getSizeHint();
 
       let left = widget.getIndentationLevel() * widget.getSpacePerIndentation();
@@ -61,17 +66,25 @@ qx.Class.define("qxl.datagrid.column.tree.ExpansionLayout", {
         }
       }
 
-      if (expander.isVisible()) {
-        expander.renderLayout(left, 0, expanderWidth, availHeight);
-        left += expanderWidth + spacing;
+      if (this.getPosition() == "start") {
+        if (expander.isVisible()) {
+          expander.renderLayout(left, 0, expanderWidth, availHeight);
+          left += expanderWidth + spacing;
+        }
+        label.renderLayout(left, 0, availWidth - left, availHeight);
+      } else {
+        let width = availWidth - left - expanderWidth - spacing;
+        label.renderLayout(left, 0, width, availHeight);
+        if ( expander.isVisible() ) {
+          left += width + spacing;
+          expander.renderLayout(left, 0, expanderWidth, availHeight);
+        }
       }
-
-      label.renderLayout(left, 0, availWidth - left, availHeight);
     },
 
     _computeSizeHint() {
       let widget = this._getWidget();
-      let expander = widget.getChildControl("expander");
+      let expander = widget.getExpander();
       let left = widget.getIndentationLevel() * widget.getSpacePerIndentation();
       let spacing = this.getSpacing();
       let expanderWidth = widget.getExpanderWidth();
@@ -91,7 +104,7 @@ qx.Class.define("qxl.datagrid.column.tree.ExpansionLayout", {
       }
 
       let width = left + expanderWidth + spacing;
-      let label = widget.getChildControl("label");
+      let label = widget.getLabel();
       let hint = label.getSizeHint(true);
       let labelWidth = hint.width;
       if (hint.minWidth && hint.minWidth > labelWidth) {

--- a/source/class/qxl/datagrid/column/tree/ExpansionWidget.js
+++ b/source/class/qxl/datagrid/column/tree/ExpansionWidget.js
@@ -136,6 +136,22 @@ qx.Class.define("qxl.datagrid.column.tree.ExpansionWidget", {
     /**
      * @Override
      */
+    getExpander() {
+      return this.getChildControl("expander");
+    },
+
+    /**
+     * Returns the widget for displaying the object
+     *
+     * @Override
+     */
+    getLabel() {
+      return this.getChildControl("label");
+    },
+
+    /**
+     * @Override
+     */
     _createChildControlImpl(id) {
       switch (id) {
         case "expander":

--- a/source/class/qxl/datagrid/column/tree/IExpansionWidget.js
+++ b/source/class/qxl/datagrid/column/tree/IExpansionWidget.js
@@ -1,0 +1,25 @@
+qx.Interface.define("qxl.datagrid.column.tree.IExpansionWidget", {
+  properties: {
+    /** How deep the indentation level is */
+    indentationLevel: {
+      init: 0,
+      check: "Integer"
+    }
+  },
+
+  members: {
+    /**
+     * Returns the expander widget
+     *
+     * @return {qx.ui.core.Widget}
+     */
+    getExpander() {},
+
+    /**
+     * Returns the widget for displaying the object
+     *
+     * @return {qx.ui.core.Widget}
+     */
+    getLabel() {}
+  }
+});

--- a/source/class/qxl/datagrid/column/tree/IExpansionWidget.js
+++ b/source/class/qxl/datagrid/column/tree/IExpansionWidget.js
@@ -1,4 +1,26 @@
-qx.Interface.define("qxl.datagrid.column.tree.IExpansionWidget", {
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+qx.Interface.define( "qxl.datagrid.column.tree.IExpansionWidget", {
   properties: {
     /** How deep the indentation level is */
     indentationLevel: {

--- a/source/class/qxl/datagrid/demo/Application.js
+++ b/source/class/qxl/datagrid/demo/Application.js
@@ -44,54 +44,7 @@ qx.Class.define("qxl.datagrid.demo.Application", {
       await qxl.datagrid.test.TestRunner.runAll(qxl.datagrid.test.ui.DataGrid);
 
       let doc = this.getRoot();
-      let tv = new qx.ui.tabview.TabView();
-      doc.add(tv, { left: 0, top: 0, right: 0, bottom: 0 });
-
-      let storage = qx.bom.Storage.getSession();
-      let lastPageId = storage.getItem(this.classname + ".lastPageId") || null;
-
-      tv.add(this.getQxObject("pgBigGridDemo"));
-      tv.add(this.getQxObject("pgTreeDemo"));
-      if (lastPageId) {
-        let page = this.getQxObject(lastPageId);
-        if (page) {
-          tv.setSelection([page]);
-        }
-      }
-
-      tv.addListener("changeSelection", evt => {
-        let page = tv.getSelection()[0] || null;
-        let id = page.getQxObjectId();
-        storage.setItem(this.classname + ".lastPageId", id);
-      });
-    },
-
-    /**
-     * @override
-     */
-    _createQxObjectImpl(id) {
-      switch (id) {
-        case "pgBigGridDemo":
-          var page = new qx.ui.tabview.Page("Big Grid Demo");
-          page.setLayout(new qx.ui.layout.Grow());
-          page.addListenerOnce("appear", async () => {
-            let demo = new qxl.datagrid.demo.biggrid.BigGridDemo();
-            page.add(demo);
-            await demo.init();
-          });
-          return page;
-
-        case "pgTreeDemo":
-          var page = new qx.ui.tabview.Page("Tree Demo");
-          page.setLayout(new qx.ui.layout.Grow());
-          page.addListenerOnce("appear", async () => {
-            let demo = new qxl.datagrid.demo.tree.TreeDemo();
-            page.add(demo);
-            await demo.init();
-          });
-          return page;
-      }
-      return super._createQxObjectImpl(id);
+      doc.add(new qxl.datagrid.demo.Demo(), { left: 0, top: 0, right: 0, bottom: 0 });
     }
   }
 });

--- a/source/class/qxl/datagrid/demo/Demo.js
+++ b/source/class/qxl/datagrid/demo/Demo.js
@@ -1,0 +1,98 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2023 Zenesis Limited https://www.zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (@johnspackman)
+     * Will Johnson (willsterjohnson)
+
+************************************************************************ */
+
+/**
+ * This is the demo application class of "qxl.datagrid"
+ *
+ * @asset(qxl/datagrid/*)
+ */
+qx.Class.define("qxl.datagrid.demo.Demo", {
+  extend: qx.ui.tabview.TabView,
+
+  /**
+   * @override
+   */
+  construct() {
+    super();
+
+    if (qx.core.Environment.get("qx.debug")) {
+      qx.log.appender.Native;
+      qx.log.appender.Console;
+    }
+
+    let storage = qx.bom.Storage.getSession();
+    let lastPageId = storage.getItem(this.classname + ".lastPageId") || null;
+
+    this.add(this.getQxObject("pgArrayDemo"));
+    this.add(this.getQxObject("pgTreeDemo"));
+    this.add(this.getQxObject("pgBigGridDemo"));
+    if (lastPageId) {
+      let page = this.getQxObject(lastPageId);
+      if (page) {
+        this.setSelection([page]);
+      }
+    }
+
+    this.addListener("changeSelection", evt => {
+      let page = this.getSelection()[0] || null;
+      let id = page.getQxObjectId();
+      storage.setItem(this.classname + ".lastPageId", id);
+    });
+  },
+
+  members: {
+    /**
+     * @override
+     */
+    _createQxObjectImpl(id) {
+      switch (id) {
+        case "pgArrayDemo":
+          const arrayPage = new qx.ui.tabview.Page("Array Demo");
+          arrayPage.setLayout(new qx.ui.layout.Grow());
+          arrayPage.addListenerOnce("appear", async () => {
+            let demo = new qxl.datagrid.demo.array.ArrayDemo();
+            arrayPage.add(demo);
+            await demo.init();
+          });
+          return arrayPage;
+
+        case "pgTreeDemo":
+          const treePage = new qx.ui.tabview.Page("Tree Demo");
+          treePage.setLayout(new qx.ui.layout.Grow());
+          treePage.addListenerOnce("appear", async () => {
+            let demo = new qxl.datagrid.demo.tree.TreeDemo();
+            treePage.add(demo);
+            await demo.init();
+          });
+          return treePage;
+
+        case "pgBigGridDemo":
+          const bigGridPage = new qx.ui.tabview.Page("Big Grid Demo");
+          bigGridPage.setLayout(new qx.ui.layout.Grow());
+          bigGridPage.addListenerOnce("appear", async () => {
+            let demo = new qxl.datagrid.demo.biggrid.BigGridDemo();
+            bigGridPage.add(demo);
+            await demo.init();
+          });
+          return bigGridPage;
+      }
+      return super._createQxObjectImpl(id);
+    }
+  }
+});

--- a/source/class/qxl/datagrid/demo/array/ArrayDemo.js
+++ b/source/class/qxl/datagrid/demo/array/ArrayDemo.js
@@ -1,0 +1,86 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Provides a simple demonstration of a DataGrid with a 1-dimensional array of
+ * data.
+ */
+qx.Class.define("qxl.datagrid.demo.array.ArrayDemo", {
+  extend: qx.ui.container.Composite,
+
+  construct() {
+    super();
+    this.setLayout(new qx.ui.layout.VBox(10));
+    let grid = this.getQxObject("grid");
+    grid;
+    this.add(grid, { flex: 1 });
+  },
+
+  members: {
+    async init() {
+      this.getQxObject("dataSource").setColumns(this.getQxObject("columns"));
+      const model = new qx.data.Array(...Array.from({ length: 100 }, () => new qxl.datagrid.demo.array.DummyModel()));
+      this.getQxObject("dataSource").setModel(model);
+    },
+
+    _createQxObjectImpl(id) {
+      switch (id) {
+        case "dataSource":
+          return new qxl.datagrid.source.ArrayDataSource();
+
+        case "grid":
+          return new qxl.datagrid.DataGrid(this.getQxObject("columns")).set({
+            dataSource: this.getQxObject("dataSource")
+          });
+
+        case "columns":
+          const columns = new qxl.datagrid.column.Columns();
+
+          columns.add(
+            new qxl.datagrid.column.TextColumn().set({
+              path: "title",
+              caption: "Title",
+              minWidth: 200,
+              flex: 1
+            })
+          );
+
+          columns.add(
+            new qxl.datagrid.column.TextColumn().set({
+              path: "author",
+              caption: "Author",
+              minWidth: 200
+            })
+          );
+
+          columns.add(
+            new qxl.datagrid.column.DateColumn().set({
+              path: "date",
+              caption: "Date",
+              minWidth: 200
+            })
+          );
+
+          return columns;
+      }
+    }
+  }
+});

--- a/source/class/qxl/datagrid/demo/array/DummyModel.js
+++ b/source/class/qxl/datagrid/demo/array/DummyModel.js
@@ -1,0 +1,127 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+qx.Class.define("qxl.datagrid.demo.array.DummyModel", {
+  extend: qx.core.Object,
+
+  construct() {
+    super();
+    this.set({
+      title: this._randomTitle(),
+      author: this._randomAuthor(),
+      date: this._randomDate()
+    });
+  },
+
+  properties: {
+    title: {
+      nullable: false,
+      check: "String",
+      event: "changeTitle"
+    },
+    author: {
+      nullable: false,
+      check: "String",
+      event: "changeAuthor"
+    },
+    date: {
+      nullable: false,
+      check: "Date",
+      event: "changeDate"
+    }
+  },
+
+  members: {
+    _randomNoun() {
+      const nouns = [
+        "Cat",
+        "Dog",
+        "Mouse",
+        "Horse",
+        "Cow",
+        "Pig",
+        "Chicken",
+        "Duck",
+        "Goose",
+        "Sheep",
+        "Goat",
+        "Rabbit",
+        "Hamster",
+        "Gerbil",
+        "Rat",
+        "Parrot",
+        "Cockatoo",
+        "Canary",
+        "Finch",
+        "Goldfish",
+        "Tropical Fish",
+        "Frog",
+        "Toad",
+        "Newt",
+        "Salamander",
+        "Lizard",
+        "Snake",
+        "Turtle",
+        "Tortoise",
+        "Crocodile",
+        "Alligator",
+        "Dinosaur",
+        "Pterodactyl",
+        "Tyrannosaurus Rex",
+        "Robin",
+        "Blue Jay",
+        "Sparrow",
+        "Owl",
+        "Eagle",
+        "Hawk",
+        "Falcon",
+        "Vulture",
+        "Penguin",
+      ];
+      return nouns[Math.floor(Math.random() * nouns.length)];
+    },
+
+    _randomTitle() {
+      const noun1 = this._randomNoun();
+      const noun2 = this._randomNoun();
+      const title = [`The ${noun1} and The ${noun2}`, `The ${noun1}'s ${noun2}`, `The ${noun1}`][Math.floor(Math.random() * 3)];
+      return title;
+    },
+
+    _randomSurname() {
+      const surnames = ["Smith", "Johnson", "Williams", "Brown", "Jones", "Miller", "Davis", "Garcia", "Rodriguez", "Wilson", "Martinez", "Anderson", "Taylor", "Thomas"];
+      return surnames[Math.floor(Math.random() * surnames.length)];
+    },
+
+    _randomAuthor() {
+      const forenameInitial = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[Math.floor(Math.random() * 26)];
+      const surname = this._randomSurname();
+      const title = ["Mr", "Mrs", "Dr", "Prof"][Math.floor(Math.random() * 4)];
+      return `${title} ${forenameInitial}. ${surname}`;
+    },
+
+    _randomDate() {
+      const now = new Date();
+      const then = new Date(now.getTime() - Math.floor(Math.random() * 15 * 365 * 24 * 60 * 60 * 1000));
+      return then;
+    }
+  }
+});

--- a/source/class/qxl/datagrid/demo/theme/tangible/Appearance.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Appearance.js
@@ -19,12 +19,7 @@
 *
 * *********************************************************************** */
 
-qx.Theme.define("qxl.datagrid.demo.theme.Theme", {
-  meta: {
-    color: qxl.datagrid.demo.theme.Color,
-    decoration: qxl.datagrid.demo.theme.Decoration,
-    font: qx.theme.tangible.Font,
-    icon: qx.theme.icon.Tango,
-    appearance: qxl.datagrid.demo.theme.Appearance
-  }
+qx.Theme.define("qxl.datagrid.demo.theme.tangible.Appearance", {
+  extend: uk.co.spar.client.theme.v2.Appearance,
+  include: [qxl.datagrid.theme.tangible.MAppearance]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Appearance.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Appearance.js
@@ -20,6 +20,6 @@
 * *********************************************************************** */
 
 qx.Theme.define("qxl.datagrid.demo.theme.tangible.Appearance", {
-  extend: uk.co.spar.client.theme.v2.Appearance,
+  extend: qx.theme.tangible.Appearance,
   include: [qxl.datagrid.theme.tangible.MAppearance]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Color.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Color.js
@@ -20,6 +20,6 @@
  * *********************************************************************** */
 
 qx.Theme.define("qxl.datagrid.demo.theme.tangible.Color", {
-  extend: uk.co.spar.client.theme.v2.ColorLight,
+  extend: qx.theme.tangible.ColorLight,
   include: [qxl.datagrid.theme.tangible.MColor]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Color.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Color.js
@@ -19,13 +19,7 @@
  *
  * *********************************************************************** */
 
-/**
- * Basic colors needed for the datagrid; this is for the Tangible theme
- */
-qx.Theme.define("qxl.datagrid.theme.MColor", {
-  colors: {
-    "qxl-datagrid-row-background-even": "surface",
-    "qxl-datagrid-row-background-odd": "primary-alpha-5",
-    "qxl-datagrid-row-selected": "primary-alpha-10"
-  }
+qx.Theme.define("qxl.datagrid.demo.theme.tangible.Color", {
+  extend: uk.co.spar.client.theme.v2.ColorLight,
+  include: [qxl.datagrid.theme.tangible.MColor]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Decoration.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Decoration.js
@@ -19,7 +19,7 @@
 *
 * *********************************************************************** */
 
-qx.Theme.define("qxl.datagrid.demo.theme.Decoration", {
-  extend: qx.theme.tangible.Decoration,
-  include: [qxl.datagrid.theme.MDecoration]
+qx.Theme.define("qxl.datagrid.demo.theme.tangible.Decoration", {
+  extend: uk.co.spar.client.theme.v2.Decoration,
+  include: [qxl.datagrid.theme.tangible.MDecoration]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Decoration.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Decoration.js
@@ -20,6 +20,6 @@
 * *********************************************************************** */
 
 qx.Theme.define("qxl.datagrid.demo.theme.tangible.Decoration", {
-  extend: uk.co.spar.client.theme.v2.Decoration,
+  extend: qx.theme.tangible.Decoration,
   include: [qxl.datagrid.theme.tangible.MDecoration]
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Theme.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Theme.js
@@ -19,8 +19,12 @@
 *
 * *********************************************************************** */
 
-qx.Theme.define("qxl.datagrid.demo.theme.Appearance", {
-  extend: qx.theme.tangible.Appearance,
-
-  include: [qxl.datagrid.theme.MAppearance]
+qx.Theme.define( "qxl.datagrid.demo.theme.tangible.Theme", {
+  meta: {
+    color: qxl.datagrid.demo.theme.tangible.Color,
+    decoration: qxl.datagrid.demo.theme.tangible.Decoration,
+    font: uk.co.spar.client.theme.v2.Font,
+    icon: qx.theme.icon.Tango,
+    appearance: qxl.datagrid.demo.theme.tangible.Appearance
+  }
 });

--- a/source/class/qxl/datagrid/demo/theme/tangible/Theme.js
+++ b/source/class/qxl/datagrid/demo/theme/tangible/Theme.js
@@ -23,7 +23,7 @@ qx.Theme.define( "qxl.datagrid.demo.theme.tangible.Theme", {
   meta: {
     color: qxl.datagrid.demo.theme.tangible.Color,
     decoration: qxl.datagrid.demo.theme.tangible.Decoration,
-    font: uk.co.spar.client.theme.v2.Font,
+    font: qx.theme.tangible.Font,
     icon: qx.theme.icon.Tango,
     appearance: qxl.datagrid.demo.theme.tangible.Appearance
   }

--- a/source/class/qxl/datagrid/source/ArrayDataSource.js
+++ b/source/class/qxl/datagrid/source/ArrayDataSource.js
@@ -1,0 +1,99 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Provides an implementation of `qxl.datagrid.source.IDataSource` for displaying a simple
+ * 1-dimensional array of data.
+ */
+qx.Class.define( "qxl.datagrid.source.ArrayDataSource", {
+  extend: qx.core.Object,
+  implement: [qxl.datagrid.source.IDataSource],
+  properties: {
+    /**
+     * The columns of the data.
+     */
+    columns: {
+      init: null,
+      nullable: true,
+      check: "qxl.datagrid.column.IColumns",
+      event: "changeColumns"
+    },
+    /**
+     * The data model to display.
+     */
+    model: {
+      init: new qx.data.Array(),
+      nullable: false,
+      check: "qx.data.Array",
+      event: "changeData"
+    }
+  },
+
+  members: {
+    /**
+     * @Override
+     */
+    isAvailable(range) {
+      return true;
+    },
+
+    /**
+     * @Override
+     */
+    async makeAvailable(range) {
+      return true;
+    },
+
+    /**
+     * @Override
+     */
+    getModelForPosition(pos) {
+      if (pos.getRow() < 0 || pos.getRow() >= this.getModel().getLength()) {
+        return null;
+      }
+      return this.getModel().getItem(pos.getRow());
+    },
+
+    /**
+     * @Override
+     */
+    getPositionOfModel(value) {
+      const rowIndex = this.getModel().indexOf(value);
+      const pos = new qxl.datagrid.source.Position(rowIndex, 0);
+      return pos;
+    },
+
+    /**
+     * @Override
+     */
+    getSize() {
+      const size = new qxl.datagrid.source.Position(this.getModel().getLength(), this.getColumns().getLength());
+      return size;
+    }
+  },
+
+  events: {
+    /**
+     * @Override
+     */
+    changeSize: "qx.event.type.Data"
+  }
+});

--- a/source/class/qxl/datagrid/source/ArrayDataSource.js
+++ b/source/class/qxl/datagrid/source/ArrayDataSource.js
@@ -23,7 +23,7 @@
  * Provides an implementation of `qxl.datagrid.source.IDataSource` for displaying a simple
  * 1-dimensional array of data.
  */
-qx.Class.define( "qxl.datagrid.source.ArrayDataSource", {
+qx.Class.define("qxl.datagrid.source.ArrayDataSource", {
   extend: qx.core.Object,
   implement: [qxl.datagrid.source.IDataSource],
   properties: {
@@ -40,14 +40,35 @@ qx.Class.define( "qxl.datagrid.source.ArrayDataSource", {
      * The data model to display.
      */
     model: {
-      init: new qx.data.Array(),
-      nullable: false,
+      init: null,
+      nullable: true,
       check: "qx.data.Array",
-      event: "changeData"
+      event: "changeModel",
+      apply: "_applyModel"
     }
   },
 
+  events: {
+    /**
+     * @Override
+     */
+    changeSize: "qx.event.type.Data"
+  },
+
   members: {
+    _applyModel(value, oldValue) {
+      if (oldValue) {
+        oldValue.removeListener("change", this.__onModelChange, this);
+      }
+      if (value) {
+        value.addListener("change", this.__onModelChange, this);
+      }
+    },
+
+    __onModelChange(evt) {
+      this.fireDataEvent("changeSize", this.getSize());
+    },
+
     /**
      * @Override
      */
@@ -88,12 +109,5 @@ qx.Class.define( "qxl.datagrid.source.ArrayDataSource", {
       const size = new qxl.datagrid.source.Position(this.getModel().getLength(), this.getColumns().getLength());
       return size;
     }
-  },
-
-  events: {
-    /**
-     * @Override
-     */
-    changeSize: "qx.event.type.Data"
   }
 });

--- a/source/class/qxl/datagrid/source/tree/NodeInspector.js
+++ b/source/class/qxl/datagrid/source/tree/NodeInspector.js
@@ -26,6 +26,14 @@ qx.Class.define("qxl.datagrid.source.tree.NodeInspector", {
   extend: qx.core.Object,
   implement: [qxl.datagrid.source.tree.INodeInspector],
 
+  construct(canHaveChildren) {
+    super();
+    this.__canHaveChildren = true;
+    if (canHaveChildren === false) {
+      this.__canHaveChildren = canHaveChildren;
+    }
+  },
+
   properties: {
     /** Where to find the children of the node */
     childrenPath: {
@@ -53,11 +61,12 @@ qx.Class.define("qxl.datagrid.source.tree.NodeInspector", {
       return null;
     },
 
+    __canHaveChildren: null,
     /**
      * @override
      */
     canHaveChildren(node) {
-      return true;
+      return this.__canHaveChildren;
     },
 
     /**

--- a/source/class/qxl/datagrid/source/tree/TreeDataSource.js
+++ b/source/class/qxl/datagrid/source/tree/TreeDataSource.js
@@ -66,10 +66,10 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
      * @property {Boolean} canHaveChildren whether the node might have children
      * @property {qxl.datagrid.binding.Bindings} childrenChangeListener Binding object for the change listener of the node's children
      *
-     * @type{RowMetaData[]} array of objects for each row */
+     * @type{RowMetaData[]} array of objects for each visible row*/
     __rowMetaDatas: null,
 
-    /** @type{Map<String,RowMetaData>} map of rows indexed by hash code of the node */
+    /** @type{Map<String,RowMetaData>} map of row metadatas for all visible rows, indexed by hash code of the node */
     __rowMetaDataByNode: null,
 
     /** @type{Promise[]?} queue of promises of background actions, eg loading nodes */
@@ -97,35 +97,47 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
 
         await this.queue(async () => {
           let row = this.__createRowMetaData(value, -1);
-          let addChildRows = async () => {
-            row.childRows = [];
-            this.__rowMetaDataByNode[value.toHashCode()] = row;
-
-            for (let i = 0, nodes = await inspector.getChildrenOf(value); i < nodes.length; i++) {
-              let node = nodes.getItem(i);
-              let childRow = this.__createRowMetaData(node, 0);
-              let childInspector = this.getNodeInspectorFactory()(node);
-
-              childRow.canHaveChildren = childInspector.canHaveChildren(node);
-              this.__rowMetaDatas.push(childRow);
-              this.__rowMetaDataByNode[node.toHashCode()] = childRow;
-              row.childRows.push(childRow);
-            }
-
-            this.fireDataEvent("changeSize", this.getSize());
-          };
+          this.__rowMetaDataByNode[value.toHashCode()] = row;
           row.canHaveChildren = inspector.canHaveChildren(value);
-          if (!row.childrenChangeBinding)
-            row.childrenChangeBinding = inspector.createChildrenChangeBinding(value, evt => {
-              this.queue(async () => {
-                this._removeChildRows(row);
-                await addChildRows();
-              });
-            });
-          await addChildRows();
+          if (!row.canHaveChildren) throw new Error("Root must be able to have children!");
+          if (!row.childrenChangeBinding) row.childrenChangeBinding = inspector.createChildrenChangeBinding(value, () => this.refreshNodeChildren(value));
+          await this._insertChildRows(value);
         });
       }
       this.fireDataEvent("changeSize", this.getSize());
+    },
+    async _insertChildRows(node) {
+      let inspector = this.getNodeInspectorFactory()(node);
+      let rowMd = this._getNodeMetaData(node);
+      rowMd.childRows = [];
+      this.__rowMetaDataByNode[node.toHashCode()] = rowMd;
+      for (let i = 0, nodes = await inspector.getChildrenOf(node); i < nodes.length; i++) {
+        let node = nodes.getItem(i);
+        let childRow = this.__createRowMetaData(node, 0);
+        let childInspector = this.getNodeInspectorFactory()(node);
+
+        childRow.canHaveChildren = childInspector.canHaveChildren(node);
+        this.__rowMetaDatas.push(childRow);
+        this.__rowMetaDataByNode[node.toHashCode()] = childRow;
+        rowMd.childRows.push(childRow);
+      }
+      this.fireDataEvent("changeSize", this.getSize());
+    },
+
+    /**
+     * Refreshes node's children. Does not preserve expanded descendants.
+     * @param {*} node
+     */
+    async refreshNodeChildren(node) {
+      await this.queue(async () => {
+        await this._collapseNode(node);
+        await this._expandNode(node);
+        this.fireDataEvent("changeSize", this.getSize());
+      });
+    },
+
+    getShownChildren(node) {
+      return this._getNodeMetaData(node).childRows.map(md => md.node);
     },
 
     /**
@@ -157,42 +169,63 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
     },
 
     /**
-     * @override
+     * Disposes of a row meta data obect
+     *
+     * @param {RowMetaData} rowMeta
      */
-    async expandNode(node) {
-      let inspector = this.getNodeInspectorFactory()(node);
-      await this.queue(async () => {
-        let children = await inspector.getChildrenOf(node);
-        let rowMetadata = this.__rowMetaDataByNode[node.toHashCode()];
-        if (!rowMetadata) {
-          throw new Error(`Cannot find ${node} in rows`);
-        }
-        if (rowMetadata.childRows || !rowMetadata.canHaveChildren) {
-          return;
-        }
-        rowMetadata.childrenChangeBinding = inspector.createChildrenChangeBinding(node, evt => {
-          this._onNodeChildrenChange(evt, node);
-        });
-        let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
-        let childRows = [];
-        for (let childNode of children) {
-          let childRow = this.__createRowMetaData(childNode, rowMetadata.level + 1);
-          childRow.canHaveChildren = inspector.canHaveChildren(childNode);
-          childRows.push(childRow);
-          this.__rowMetaDataByNode[childNode.toHashCode()] = childRow;
-        }
-        let before = this.__rowMetaDatas.slice(0, parentRowIndex + 1);
-        let after = parentRowIndex == this.__rowMetaDatas.length - 1 ? [] : this.__rowMetaDatas.slice(parentRowIndex + 1);
-        qx.lang.Array.append(before, childRows);
-        qx.lang.Array.append(before, after);
-        rowMetadata.childRows = childRows;
-        this.__rowMetaDatas = before;
-        this.fireDataEvent("changeSize", this.getSize());
-      });
+    __disposeRowMetaData(rowMeta) {
+      if (rowMeta.childrenChangeBinding) {
+        rowMeta.childrenChangeBinding.dispose();
+        delete rowMeta.childrenChangeBinding;
+      }
     },
 
     /**
-     * Reveals node in tree, even if it's not current shown.
+     * Returns node metadata for the node object
+     */
+    _getNodeMetaData(node) {
+      return this.__rowMetaDataByNode[node.toHashCode()];
+    },
+
+    /**@override */
+    async expandNode(node) {
+      await this.queue(() => this._expandNode(node));
+    },
+    /**
+     * Expands given node.
+     * Is called inside of this class, so its operation is not queued.
+     * @param {*} node
+     */
+    async _expandNode(node) {
+      let inspector = this.getNodeInspectorFactory()(node);
+      let children = await inspector.getChildrenOf(node);
+      let rowMetadata = this._getNodeMetaData(node);
+      if (!rowMetadata) {
+        throw new Error(`Cannot find ${node} in rows`);
+      }
+      if (rowMetadata.childRows || !rowMetadata.canHaveChildren) {
+        return;
+      }
+      rowMetadata.childrenChangeBinding = inspector.createChildrenChangeBinding(node, () => this.refreshNodeChildren(node));
+      let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
+      let childRows = [];
+      for (let childNode of children) {
+        let childRow = this.__createRowMetaData(childNode, rowMetadata.level + 1);
+        childRow.canHaveChildren = inspector.canHaveChildren(childNode);
+        childRows.push(childRow);
+        this.__rowMetaDataByNode[childNode.toHashCode()] = childRow;
+      }
+      let before = this.__rowMetaDatas.slice(0, parentRowIndex + 1);
+      let after = parentRowIndex == this.__rowMetaDatas.length - 1 ? [] : this.__rowMetaDatas.slice(parentRowIndex + 1);
+      qx.lang.Array.append(before, childRows);
+      qx.lang.Array.append(before, after);
+      rowMetadata.childRows = childRows;
+      this.__rowMetaDatas = before;
+      this.fireDataEvent("changeSize", this.getSize());
+    },
+
+    /**
+     * Reveals node in tree, even if it's not currently shown.
      * All ancestors of node are expanded.
      * @param {qx.data.Object} node
      */
@@ -216,61 +249,41 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
         let ancestors = getPathToNode(node);
         if (!ancestors) throw new Error("Cannot find node in tree");
         for (var a = 0; a < ancestors.length; a++) {
-          await this.expandNode(ancestors.getItem(a));
+          await this._expandNode(ancestors.getItem(a));
         }
       });
     },
 
-    /**
-     * This function is called when the children of a node in the tree changes.
-     * It causes the grid view to update.
-     * @param {qx.data.Event} evt Event for a change in the node's children array
-     * @param {qx.core.Object} node The node object for which the children changed
-     */
-    async _onNodeChildrenChange(evt, node) {
-      let rowMetadata = this.__rowMetaDataByNode[node.toHashCode()];
-      let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
-      let changeStart = parentRowIndex + 1;
-      let changeEnd = changeStart + rowMetadata.childRows.length;
-      let before = this.__rowMetaDatas.slice(0, changeStart);
-      let after = changeEnd == this.__rowMetaDatas.length ? [] : this.__rowMetaDatas.slice(changeEnd);
-      await this.queue(async () => {
-        for (let childRow of rowMetadata.childRows) {
-          this._removeChildRows(childRow);
-        }
-        rowMetadata.childRows = [];
-        let newRowsMetaDatas = [];
-        for (let childNode of node.getChildren()) {
-          let inspector = this.getNodeInspectorFactory()(childNode);
-          let childRowMetadata = this.__createRowMetaData(childNode, rowMetadata.level + 1);
-          newRowsMetaDatas.push(childRowMetadata);
-          childRowMetadata.canHaveChildren = inspector.canHaveChildren(childNode);
-          rowMetadata.childRows.push(childRowMetadata);
-          this.__rowMetaDataByNode[childNode.toHashCode()] = childRowMetadata;
-        }
-        qx.lang.Array.append(before, newRowsMetaDatas);
-        qx.lang.Array.append(before, after);
-        this.__rowMetaDatas = before;
-        this.fireDataEvent("changeSize", this.getSize());
-      });
-    },
 
     /**
      * @override
      */
     async collapseNode(node) {
-      await this.queue(async () => {
-        let rowMetaData = this.__rowMetaDataByNode[node.toHashCode()];
-        if (!rowMetaData) {
-          throw new Error(`Cannot find ${node} in rows`);
-        }
-        if (!rowMetaData.childRows) {
-          return;
-        }
-        this.__disposeRowMetaData(rowMetaData);
-        this._removeChildRows(rowMetaData);
-        this.fireDataEvent("changeSize", this.getSize());
-      });
+      await this.queue(this._collapseNode.bind(this, node));
+    },
+
+    async _collapseNode(node) {
+      let row = this.__rowMetaDataByNode[node.toHashCode()];
+      if (!row) {
+        throw new Error(`Cannot find ${node} in rows`);
+      }
+      if (!row.childRows) {
+        return;
+      }
+      if (row.childrenChangeBinding) {
+        row.childrenChangeBinding.dispose();
+        delete row.childrenChangeBinding;
+      }
+      this._removeChildRows(row);
+      this.fireDataEvent("changeSize", this.getSize());
+    },
+
+    /**
+     * Performs a full update of the nodes in the tree,
+     * such that all the children of the expanded nodes are shown
+     */
+    async updateNodes() {
+      return this.refreshNodeChildren(this.getRoot());
     },
 
     /**

--- a/source/class/qxl/datagrid/source/tree/TreeDataSource.js
+++ b/source/class/qxl/datagrid/source/tree/TreeDataSource.js
@@ -209,9 +209,10 @@ qx.Class.define("qxl.datagrid.source.tree.TreeDataSource", {
       rowMetadata.childrenChangeBinding = inspector.createChildrenChangeBinding(node, () => this.refreshNodeChildren(node));
       let parentRowIndex = this.__rowMetaDatas.indexOf(rowMetadata);
       let childRows = [];
-      for (let childNode of children) {
+      for ( let childNode of children ) {
+        const childInspector = this.getNodeInspectorFactory()(childNode);
         let childRow = this.__createRowMetaData(childNode, rowMetadata.level + 1);
-        childRow.canHaveChildren = inspector.canHaveChildren(childNode);
+        childRow.canHaveChildren = childInspector.canHaveChildren(childNode);
         childRows.push(childRow);
         this.__rowMetaDataByNode[childNode.toHashCode()] = childRow;
       }

--- a/source/class/qxl/datagrid/theme/indigo/MAppearance.js
+++ b/source/class/qxl/datagrid/theme/indigo/MAppearance.js
@@ -1,0 +1,83 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic appearances needed for the datagrid; this is for the Indigo theme
+ */
+qx.Theme.define("qxl.datagrid.theme.indigo.MAppearance", {
+  appearances: {
+    "qxl-datagrid": "widget",
+    "qxl-datagrid/scrollbar-x": "scrollbar",
+    "qxl-datagrid/scrollbar-y": "scrollbar",
+
+    "qxl-datagrid-header": "table-scroller/header",
+    "qxl-datagrid-header-cell": "widget",
+
+    "qxl-datagrid-widgetpane": {
+      style(states) {
+        return {
+          backgroundColor: "transparent"
+        };
+      }
+    },
+
+    "qxl-datagrid-cell": {
+      style(states) {
+        let backgroundColor = "transparent";
+        let textColor = "qxl-datagrid-row";
+        let decorator;
+        if (states.selected) {
+          backgroundColor = "qxl-datagrid-row-background-selected";
+          textColor = "qxl-datagrid-row-selected";
+        }
+        if (states.focused) {
+          decorator = "qxl-datagrid-cell-focused";
+        }
+        return {
+          backgroundColor,
+          textColor,
+          decorator
+        };
+      }
+    },
+    "qxl-datagrid-row": {
+      style(states) {
+        let backgroundColor = "qxl-datagrid-row-background-even";
+        let textColor = "qxl-datagrid-row";
+        if (states.selected) {
+          backgroundColor = "qxl-datagrid-row-background-selected";
+          textColor = "qxl-datagrid-row-selected";
+        } else if (states.odd) {
+          backgroundColor = "qxl-datagrid-row-background-odd";
+        }
+        let decorator = "qxl-datagrid-row";
+        if (states.focused) {
+          decorator += "-focused";
+        }
+        return {
+          backgroundColor,
+          textColor,
+          decorator
+        };
+      }
+    }
+  }
+});

--- a/source/class/qxl/datagrid/theme/indigo/MColor.js
+++ b/source/class/qxl/datagrid/theme/indigo/MColor.js
@@ -1,0 +1,33 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic colors needed for the datagrid; this is for the Indigo theme
+ */
+qx.Theme.define("qxl.datagrid.theme.indigo.MColor", {
+  colors: {
+    "qxl-datagrid-row-background-even": "table-row-background-even",
+    "qxl-datagrid-row-background-odd": "table-row-background-odd",
+    "qxl-datagrid-row-background-selected": "table-row-background-selected",
+    "qxl-datagrid-row-selected": "table-row-selected",
+    "qxl-datagrid-row": "table-row"
+  }
+});

--- a/source/class/qxl/datagrid/theme/indigo/MDecoration.js
+++ b/source/class/qxl/datagrid/theme/indigo/MDecoration.js
@@ -1,0 +1,53 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic decorations needed for the datagrid; this is for the Indigo theme
+ */
+qx.Theme.define("qxl.datagrid.theme.indigo.MDecoration", {
+  decorations: {
+    "qxl-datagrid-row": {
+      style: {
+        radius: 0,
+        color: "table-row",
+        width: [0, 0, 1, 0]
+      }
+    },
+
+    "qxl-datagrid-row-focused": {
+      style: {
+        radius: 0,
+        color: "table-row-selected",
+        width: 1,
+        style: "dashed"
+      }
+    },
+
+    "qxl-datagrid-cell-focused": {
+      style: {
+        radius: 0,
+        width: 1,
+        color: "table-row-selected",
+        style: "dashed"
+      }
+    }
+  }
+});

--- a/source/class/qxl/datagrid/theme/simple/MAppearance.js
+++ b/source/class/qxl/datagrid/theme/simple/MAppearance.js
@@ -15,14 +15,14 @@
  *      for details.
  *
  *    Authors:
- *      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+ *      * Will Johnson (willsterjohnson)
  *
  * *********************************************************************** */
 
 /**
- * Basic appearances needed for the datagrid; this is for the Tangible theme
+ * Basic appearances needed for the datagrid; this is for the Simple theme
  */
-qx.Theme.define("qxl.datagrid.theme.MAppearance", {
+qx.Theme.define("qxl.datagrid.theme.simple.MAppearance", {
   appearances: {
     "qxl-datagrid": "widget",
     "qxl-datagrid/scrollbar-x": "scrollbar",
@@ -42,15 +42,18 @@ qx.Theme.define("qxl.datagrid.theme.MAppearance", {
     "qxl-datagrid-cell": {
       style(states) {
         let backgroundColor = "transparent";
+        let textColor = "qxl-datagrid-row";
         let decorator;
         if (states.selected) {
-          backgroundColor = "qxl-datagrid-row-selected";
+          backgroundColor = "qxl-datagrid-row-background-selected";
+          textColor = "qxl-datagrid-row-selected";
         }
         if (states.focused) {
           decorator = "qxl-datagrid-cell-focused";
         }
         return {
           backgroundColor,
+          textColor,
           decorator
         };
       }
@@ -58,8 +61,10 @@ qx.Theme.define("qxl.datagrid.theme.MAppearance", {
     "qxl-datagrid-row": {
       style(states) {
         let backgroundColor = "qxl-datagrid-row-background-even";
+        let textColor = "qxl-datagrid-row";
         if (states.selected) {
-          backgroundColor = "qxl-datagrid-row-selected";
+          backgroundColor = "qxl-datagrid-row-background-selected";
+          textColor = "qxl-datagrid-row-selected";
         } else if (states.odd) {
           backgroundColor = "qxl-datagrid-row-background-odd";
         }
@@ -69,6 +74,7 @@ qx.Theme.define("qxl.datagrid.theme.MAppearance", {
         }
         return {
           backgroundColor,
+          textColor,
           decorator
         };
       }

--- a/source/class/qxl/datagrid/theme/simple/MColor.js
+++ b/source/class/qxl/datagrid/theme/simple/MColor.js
@@ -1,0 +1,33 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic colors needed for the datagrid; this is for the Simple theme
+ */
+qx.Theme.define("qxl.datagrid.theme.simple.MColor", {
+  colors: {
+    "qxl-datagrid-row-background-even": "table-row-background-even",
+    "qxl-datagrid-row-background-odd": "table-row-background-odd",
+    "qxl-datagrid-row-background-selected": "table-row-background-selected",
+    "qxl-datagrid-row-selected": "table-row-selected",
+    "qxl-datagrid-row": "table-row"
+  }
+});

--- a/source/class/qxl/datagrid/theme/simple/MDecoration.js
+++ b/source/class/qxl/datagrid/theme/simple/MDecoration.js
@@ -1,0 +1,53 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * Will Johnson (willsterjohnson)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic decorations needed for the datagrid; this is for the Simple theme
+ */
+qx.Theme.define("qxl.datagrid.theme.simple.MDecoration", {
+  decorations: {
+    "qxl-datagrid-row": {
+      style: {
+        radius: 0,
+        color: "table-row",
+        width: [0, 0, 1, 0]
+      }
+    },
+
+    "qxl-datagrid-row-focused": {
+      style: {
+        radius: 0,
+        color: "table-row-selected",
+        width: 1,
+        style: "dashed"
+      }
+    },
+
+    "qxl-datagrid-cell-focused": {
+      style: {
+        radius: 0,
+        width: 1,
+        color: "table-row-selected",
+        style: "dashed"
+      }
+    }
+  }
+});

--- a/source/class/qxl/datagrid/theme/tangible/MAppearance.js
+++ b/source/class/qxl/datagrid/theme/tangible/MAppearance.js
@@ -1,0 +1,77 @@
+/* ************************************************************************
+ *
+ *    Qooxdoo DataGrid
+ *
+ *    https://github.com/qooxdoo/qooxdoo
+ *
+ *    Copyright:
+ *      2022-23 Zenesis Limited, https://www.zenesis.com
+ *
+ *    License:
+ *      MIT: https://opensource.org/licenses/MIT
+ *
+ *      This software is provided under the same licensing terms as Qooxdoo,
+ *      please see the LICENSE file in the Qooxdoo project's top-level directory
+ *      for details.
+ *
+ *    Authors:
+ *      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+ *
+ * *********************************************************************** */
+
+/**
+ * Basic appearances needed for the datagrid; this is for the Tangible theme
+ */
+qx.Theme.define("qxl.datagrid.theme.tangible.MAppearance", {
+  appearances: {
+    "qxl-datagrid": "widget",
+    "qxl-datagrid/scrollbar-x": "scrollbar",
+    "qxl-datagrid/scrollbar-y": "scrollbar",
+
+    "qxl-datagrid-header": "table-scroller/header",
+    "qxl-datagrid-header-cell": "widget",
+
+    "qxl-datagrid-widgetpane": {
+      style(states) {
+        return {
+          backgroundColor: "transparent"
+        };
+      }
+    },
+
+    "qxl-datagrid-cell": {
+      style(states) {
+        let backgroundColor = "transparent";
+        let decorator;
+        if (states.selected) {
+          backgroundColor = "qxl-datagrid-row-background-selected";
+        }
+        if (states.focused) {
+          decorator = "qxl-datagrid-cell-focused";
+        }
+        return {
+          backgroundColor,
+          decorator
+        };
+      }
+    },
+    "qxl-datagrid-row": {
+      style(states) {
+        let backgroundColor = "qxl-datagrid-row-background-even";
+        if (states.selected) {
+          backgroundColor = "qxl-datagrid-row-background-selected";
+        } else if (states.odd) {
+          backgroundColor = "qxl-datagrid-row-background-odd";
+        }
+        let decorator = "qxl-datagrid-row";
+        if (states.focused) {
+          decorator += "-focused";
+        }
+        return {
+          backgroundColor,
+          decorator
+        };
+      }
+    }
+  }
+});

--- a/source/class/qxl/datagrid/theme/tangible/MColor.js
+++ b/source/class/qxl/datagrid/theme/tangible/MColor.js
@@ -19,7 +19,13 @@
  *
  * *********************************************************************** */
 
-qx.Theme.define("qxl.datagrid.demo.theme.Color", {
-  extend: qx.theme.tangible.ColorLight,
-  include: [qxl.datagrid.theme.MColor]
+/**
+ * Basic colors needed for the datagrid; this is for the Tangible theme
+ */
+qx.Theme.define("qxl.datagrid.theme.tangible.MColor", {
+  colors: {
+    "qxl-datagrid-row-background-even": "surface",
+    "qxl-datagrid-row-background-odd": "primary-alpha-5",
+    "qxl-datagrid-row-background-selected": "primary-alpha-10"
+  }
 });

--- a/source/class/qxl/datagrid/theme/tangible/MDecoration.js
+++ b/source/class/qxl/datagrid/theme/tangible/MDecoration.js
@@ -22,7 +22,7 @@
 /**
  * Basic decorations needed for the datagrid; this is for the Tangible theme
  */
-qx.Theme.define("qxl.datagrid.theme.MDecoration", {
+qx.Theme.define("qxl.datagrid.theme.tangible.MDecoration", {
   decorations: {
     "qxl-datagrid-row": {
       style: {

--- a/source/class/qxl/datagrid/ui/GridSizeCalculator.js
+++ b/source/class/qxl/datagrid/ui/GridSizeCalculator.js
@@ -106,6 +106,12 @@ qx.Class.define("qxl.datagrid.ui.GridSizeCalculator", {
     /** @type{Integer} the first column in the data source */
     _startColumnIndex: null,
 
+    /** @type{Integer} the left scroll position */
+    _left: null,
+
+    /** @type{Integer} the top scroll position */
+    _top: null,
+
     /**
      * Gets the sizes for a given set of available size or scroll position
      *
@@ -116,7 +122,7 @@ qx.Class.define("qxl.datagrid.ui.GridSizeCalculator", {
      * @returns {SizesData}
      */
     getSizesFor(width, height, startRowIndex, startColumnIndex) {
-      this.setAvailableSize(width, height, startRowIndex, startColumnIndex);
+      this.setAvailableSize(width, height, startRowIndex, startColumnIndex, 0, 0);
       return this.getSizes();
     },
 
@@ -128,15 +134,19 @@ qx.Class.define("qxl.datagrid.ui.GridSizeCalculator", {
      * @param {Integer} height
      * @param {Integer} startRowIndex
      * @param {Integer} startColumnIndex
+     * @param {Integer} left
+     * @param {Integer} top
      * @returns {Boolean} true if the widgets need to be redrawn because the previous data is invalid
      */
-    setAvailableSize(width, height, startRowIndex, startColumnIndex) {
+    setAvailableSize(width, height, startRowIndex, startColumnIndex, left, top) {
       if (width !== this._width || height !== this._height || startRowIndex != this._startRowIndex || startColumnIndex != this._startColumnIndex) {
         this.invalidate();
         this._width = width;
         this._height = height;
         this._startRowIndex = startRowIndex;
         this._startColumnIndex = startColumnIndex;
+        this._left = left;
+        this._top = top;
       }
       return !this.__sizes;
     },
@@ -151,6 +161,18 @@ qx.Class.define("qxl.datagrid.ui.GridSizeCalculator", {
         this.__sizes = this._calculateSizes();
       }
       return this.__sizes;
+    },
+
+    /**
+     * Gets the left and top initial offsets
+     *
+     * @returns {Map} with keys "left" and "top"
+     */
+    getInitialOffsets() {
+      return {
+        left: this._left,
+        top: this._top
+      };
     },
 
     /**

--- a/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
+++ b/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
@@ -107,7 +107,7 @@ qx.Class.define("qxl.datagrid.ui.OddEvenRowBackgrounds", {
       let rowWidth = 0;
       sizesData.columns.forEach(cd => (rowWidth += cd.width));
 
-      let top = 0;
+      let top = this.__sizeCalculator.getInitialOffsets().top;
       let verticalSpacing = styling.getVerticalSpacing();
       let spaceAbove = Math.ceil(verticalSpacing / 2);
       let spaceBelow = verticalSpacing - spaceAbove;
@@ -157,7 +157,7 @@ qx.Class.define("qxl.datagrid.ui.OddEvenRowBackgrounds", {
         }
 
         child.setLayoutProperties({
-          left: 0,
+          left: this.__sizeCalculator.getInitialOffsets().left,
           width: rowWidth,
           top: top - spaceAbove,
           height: rowSizeData.height + spaceAbove + spaceBelow

--- a/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
+++ b/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
@@ -175,7 +175,15 @@ qx.Class.define("qxl.datagrid.ui.OddEvenRowBackgrounds", {
     _createRowWidget() {
       return new qx.ui.basic.Atom().set({
         appearance: this.__widgetAppearance
-      });
+      } );
+    },
+
+    /**
+     * Allows row appearance to be set outside of the constructor
+     */
+    setRowAppearance(appearance) {
+      this.__widgetAppearance = appearance;
+      this._getChildren().forEach(child => child.setAppearance(appearance));
     }
   }
 });

--- a/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
+++ b/source/class/qxl/datagrid/ui/OddEvenRowBackgrounds.js
@@ -93,7 +93,7 @@ qx.Class.define("qxl.datagrid.ui.OddEvenRowBackgrounds", {
       qx.lang.Array.clone(this._getChildren()).forEach(child => {
         let cellData = child.getUserData("qxl.datagrid.cellData");
         // prettier-ignore
-        if (cellData.row < minDataRowIndex || 
+        if (cellData.row < minDataRowIndex ||
             cellData.row > maxRowIndex) {
           child.setUserData("qxl.datagrid.cellData", null);
           this._remove(child);

--- a/source/class/qxl/datagrid/ui/WidgetPane.js
+++ b/source/class/qxl/datagrid/ui/WidgetPane.js
@@ -137,11 +137,7 @@ qx.Class.define("qxl.datagrid.ui.WidgetPane", {
       qx.lang.Array.clone(this._getChildren()).forEach(child => {
         let cellData = child.getUserData("qxl.datagrid.cellData");
         // prettier-ignore
-        if (invalidateAll ||
-            cellData.row < minDataRowIndex || 
-            cellData.row > maxRowIndex || 
-            cellData.column < minColumnIndex || 
-            cellData.column > maxColumnIndex) {
+        if (invalidateAll || cellData.row < minDataRowIndex || cellData.row > maxRowIndex || cellData.column < minColumnIndex || cellData.column > maxColumnIndex) {
           this.__widgetFactory.unbindWidget(child);
           child.setUserData("qxl.datagrid.cellData", null);
           this._remove(child);
@@ -185,6 +181,9 @@ qx.Class.define("qxl.datagrid.ui.WidgetPane", {
           if (this.__selectionManager.getSelectionStyle() == "cell") {
             isSelected = this.__selectionManager.isSelected(model);
             isFocused = this.__selectionManager.getFocused() === model;
+          } else {
+            let rowModel = this.getDataSource().getModelForPosition(new qxl.datagrid.source.Position(rowSizeData.rowIndex, 0));
+            isSelected = this.__selectionManager.isSelected(rowModel);
           }
           if (isSelected) {
             child.addState("selected");

--- a/source/class/qxl/datagrid/ui/factory/AbstractWidgetFactory.js
+++ b/source/class/qxl/datagrid/ui/factory/AbstractWidgetFactory.js
@@ -29,13 +29,10 @@ qx.Class.define("qxl.datagrid.ui.factory.AbstractWidgetFactory", {
 
   /**
    * Constructor
-   *
-   * @param {String} widgetAppearance the appearance to set on the widget
    */
-  construct(columns, widgetAppearance) {
+  construct(columns) {
     super();
     this.__widgets = {};
-    this.__widgetAppearance = widgetAppearance;
     if (columns) {
       this.setColumns(columns);
     }
@@ -60,10 +57,10 @@ qx.Class.define("qxl.datagrid.ui.factory.AbstractWidgetFactory", {
   },
 
   members: {
-    /** @type{Map<String,qx.ui.core.Widget>} the widgets, indexed by row:column */
+    /** @type {Record<string, qx.ui.core.Widget>} the widgets, indexed by row:column */
     __widgets: null,
 
-    /** @type{String} the appearance to set on each widget */
+    /** @type {string} the appearance to set on each widget */
     __widgetAppearance: null,
 
     /**
@@ -92,7 +89,9 @@ qx.Class.define("qxl.datagrid.ui.factory.AbstractWidgetFactory", {
       if (!widget) {
         let column = this.getColumns().getColumn(columnIndex);
         widget = this.__widgets[id] = this._createWidget(column);
-        widget.setAppearance(this.__widgetAppearance);
+        if (this.__widgetAppearance) {
+          widget.setAppearance(this.__widgetAppearance);
+        }
         widget.setUserData("qxl.datagrid.factory.AbstractWidgetFactory.bindingData", {
           rowIndex: rowIndex,
           columnIndex: columnIndex,
@@ -141,6 +140,18 @@ qx.Class.define("qxl.datagrid.ui.factory.AbstractWidgetFactory", {
      */
     getWidgets() {
       return this.__widgets;
+    },
+
+    /**
+     * Updates all widgets to the new appearance, and sets the
+     * appearance for new widgets
+     * @param appearance {string} the appearance
+     */
+    setChildAppearances(appearance) {
+      this.__widgetAppearance = appearance;
+      Object.values(this.getWidgets()).forEach(widget => {
+        widget.setAppearance(this.__widgetAppearance);
+      });
     }
   }
 });

--- a/source/class/qxl/datagrid/ui/factory/HeaderWidgetFactory.js
+++ b/source/class/qxl/datagrid/ui/factory/HeaderWidgetFactory.js
@@ -52,7 +52,9 @@ qx.Class.define("qxl.datagrid.ui.factory.HeaderWidgetFactory", {
      * @override
      */
     _createWidget() {
-      return new qx.ui.basic.Atom();
+      return new qx.ui.basic.Atom().set({
+        appearance: "qxl-datagrid-header-cell"
+      });
     }
   }
 });

--- a/source/class/qxl/datagrid/util/Math.js
+++ b/source/class/qxl/datagrid/util/Math.js
@@ -1,0 +1,34 @@
+qx.Class.define("qxl.datagrid.util.Math", {
+  statics: {
+    /**
+     * Clamps x between values lo and hi inclusive
+     * i.e. if x < lo, return lo. else if y > hi, return hi, else return x.
+     * @param {*} lo
+     * @param {*} hi
+     * @param {*} x
+     * @returns
+     */
+    clamp(lo, hi, x) {
+      x = Math.max(lo, x);
+      x = Math.min(hi, x);
+      return x;
+    },
+
+    /**
+     * Maps x, which is in range a1-a2, to range b1-b2.
+     *
+     * Examples:
+     * interpolate(0,10,0,100,0) = 0
+     * interpolate(0,10,0,100,10) = 100
+     * interpolate(0,10,0,100,5.5) = 55
+     * @param {Number} a1
+     * @param {Number} a2
+     * @param {Number} b1
+     * @param {Number} b2
+     * @param {Number} x
+     */
+    interpolate(a1, a2, b1, b2, x) {
+      return b1 + ((x - a1) * (b2 - b1)) / (a2 - a1);
+    }
+  }
+});


### PR DESCRIPTION
- Adds the array data source for list-like datagrid views
- Adds sample mixins for common themes
- Configurable `canHaveChildren` for `NodeInspector` as constructor param
- Improved grid size calculations
- Configurable row appearances at runtime
- Documentation changes & additions

This also merges several commits from @p9malino26